### PR TITLE
feat: make template customizable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export const name = 'go-cqhttp'
 
 export interface Config {
   root?: string
+  templatePath?: string
   logLevel?: number
 }
 
@@ -67,7 +68,8 @@ async function start(bot: OneBotBot, config: Config) {
   // create config.yml
   const { port, host = 'localhost' } = bot.app.options
   const { path = '/onebot' } = bot.app.registry.get(onebot).config
-  const template = await readFile(resolve(__dirname, '../template.yml'), 'utf8')
+  const templatePath = config.templatePath ? resolve(config.templatePath) : resolve(__dirname, '../template/config.yml')
+  const template = await readFile(templatePath, 'utf8')
   await writeFile(cwd + '/config.yml', interpolate(template, {
     bot: bot.config,
     adapter: bot.adapter.config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export const name = 'go-cqhttp'
 
 export interface Config {
   root?: string
+  template?: string
   templatePath?: string
   logLevel?: number
 }
@@ -69,7 +70,7 @@ async function start(bot: OneBotBot, config: Config) {
   const { port, host = 'localhost' } = bot.app.options
   const { path = '/onebot' } = bot.app.registry.get(onebot).config
   const templatePath = config.templatePath ? resolve(config.templatePath) : resolve(__dirname, '../template/config.yml')
-  const template = await readFile(templatePath, 'utf8')
+  const template = config.template ?? await readFile(templatePath, 'utf8')
   await writeFile(cwd + '/config.yml', interpolate(template, {
     bot: bot.config,
     adapter: bot.adapter.config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ async function start(bot: OneBotBot, config: Config) {
   const { path = '/onebot' } = bot.app.registry.get(onebot).config
   const template = await readFile(
     config.template
-      ? resolve(config.template)
+      ? resolve(bot.app.baseDir, config.template)
       : resolve(__dirname, '../template/config.yml'),
     'utf8',
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,8 @@ async function start(bot: OneBotBot, config: Config) {
   const template = await readFile(
     config.template
       ? resolve(config.template)
-      : resolve(__dirname, '../template/config.yml'), 'utf8',
+      : resolve(__dirname, '../template/config.yml'),
+    'utf8',
   )
   await writeFile(cwd + '/config.yml', interpolate(template, {
     bot: bot.config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ export const name = 'go-cqhttp'
 export interface Config {
   root?: string
   template?: string
-  templatePath?: string
   logLevel?: number
 }
 
@@ -69,8 +68,11 @@ async function start(bot: OneBotBot, config: Config) {
   // create config.yml
   const { port, host = 'localhost' } = bot.app.options
   const { path = '/onebot' } = bot.app.registry.get(onebot).config
-  const templatePath = config.templatePath ? resolve(config.templatePath) : resolve(__dirname, '../template/config.yml')
-  const template = config.template ?? await readFile(templatePath, 'utf8')
+  const template = await readFile(
+    config.template
+      ? resolve(config.template)
+      : resolve(__dirname, '../template/config.yml'), 'utf8',
+  )
   await writeFile(cwd + '/config.yml', interpolate(template, {
     bot: bot.config,
     adapter: bot.adapter.config,


### PR DESCRIPTION
Add an option to provide file path of user-customized `template.yml`.

I think this is an advanced feature that most people don't need or don't know how to use, so add in `interface` only, not in `Schema`.