### PR TITLE
fix: fix incorrect endpoint for ws and http

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ class Launcher extends DataService<Dict<Data>> {
       ...bot.config.gocqhttp,
     }
     if ('endpoint' in config) {
-      config.endpoint = `127.0.0.1:${this.ctx.router.port}`
+      config.endpoint = `127.0.0.1:${new URL(config.endpoint).port}`
     }
     if ('path' in config) {
       const { port, host = 'localhost' } = bot.ctx.root.config


### PR DESCRIPTION
`this.ctx.router.port` 是 koishi 监听的端口号，而非设置的 go-cqhttp 应该监听的端口号 (`new URL(config.endpoint).port`)