### PR TITLE
fix: fix `selfUrl` for `ws-resverse`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,8 +168,7 @@ class Launcher extends DataService<Dict<Data>> {
       config.endpoint = `127.0.0.1:${this.ctx.router.port}`
     }
     if ('path' in config) {
-      const { port, host = 'localhost' } = bot.ctx.root.config
-      config['selfUrl'] = `${host}:${port}${config.path}`
+      config['selfUrl'] = `127.0.0.1:${this.ctx.router.port}${config.path}`
     }
     return interpolate(template, config, /\$\{\{(.+?)\}\}/g)
   }


### PR DESCRIPTION
注意到 [该 PR](https://github.com/koishijs/koishi-plugin-gocqhttp/pull/17) 指出 [该提交](https://github.com/koishijs/koishi-plugin-gocqhttp/commit/f014bddfc20ca5ce871b2c853c158c1eac4d5e7b) 可能是错误的，那么 [该评论](https://github.com/koishijs/koishi-plugin-gocqhttp/pull/17#issuecomment-153752772) 所提到的问题可能从未被修复。此 PR 意图修复此问题。

此 PR 对 `ws-resverse` 所唯一使用的 `selfUrl` 配置进行了如下修改：

- 和 [这个错误的提交](https://github.com/koishijs/koishi-plugin-gocqhttp/commit/f014bddfc20ca5ce871b2c853c158c1eac4d5e7b) 的做法相同，将 `port` 修改为使用 `this.ctx.router.port`。
- 将 `host` 强制设置为 `127.0.0.1`。理由在 [Koishi 的修改](https://github.com/satorijs/satori/commit/241d57dd7b457214be12a1109b6b20ee23fb519a) 和 [上个 PR](https://github.com/koishijs/koishi-plugin-gocqhttp/pull/17) 中均有阐述。同时注意这使得此处的 `selfUrl` 为本段代码专用，和其他作用域的 `selfUrl` 的意义不同。
